### PR TITLE
Back port debug test.py to python 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ UpgradeLog*.htm
 .vscode
 vcpkg_installed
 output/
+*testout*
+sDNA/sdna_vs2008/tests/odtest.*
+sDNA/sdna_vs2008/tests/regtestresids_py3.*
+sDNA/sdna_vs2008/tests/tinypred_py3.*
+sDNA/sdna_vs2008/tests/geom_test_py3.txt

--- a/sDNA/sdna_vs2008/tests/debug_test.py
+++ b/sDNA/sdna_vs2008/tests/debug_test.py
@@ -9,6 +9,7 @@ class my_void_p(ctypes.c_void_p):
     pass
 
 sdnadll = os.environ["sdnadll"]
+# print(f'{sdnadll=}')
 dll = ctypes.windll.LoadLibrary(sdnadll)
 
 dll.run_unit_tests()
@@ -16,6 +17,12 @@ print()
 
 # now using strings rather than enum so this looks a bit tautological, but:
 (ANGULAR, EUCLIDEAN, CUSTOM, HYBRID) = ("ANGULAR","EUCLIDEAN","CUSTOM","HYBRID")
+
+def bytes_to_ascii(x):
+    """ Python 2 compatible replacement for str(x, 'ascii').
+        str accepts one argument only, in Python 2.  
+    """
+    return x.decode('ascii')
 
 current_net_arcids = None
 
@@ -26,7 +33,7 @@ def set_progressor(x):
 set_progressor_callback = CALLBACKFUNCTYPE(set_progressor)
 WARNINGCALLBACKFUNCTYPE = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p)
 def warning(x):
-    print(str(x,"ascii"))
+    print(bytes_to_ascii(x))
     return 0
 warning_callback = WARNINGCALLBACKFUNCTYPE(warning)
 
@@ -154,17 +161,17 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
     dll.icalc_get_output_length.restype = ctypes.c_int
     outlength = dll.icalc_get_output_length(calculation)
     names = dll.icalc_get_all_output_names(calculation)
-    names = [str(x,"ascii") for x in names[0:outlength]]
+    names = [bytes_to_ascii(x) for x in names[0:outlength]]
     dll.icalc_get_short_output_names.restype = ctypes.POINTER(ctypes.c_char_p)
     shortnames = dll.icalc_get_short_output_names(calculation)
     sn=[]
     for i in range(outlength):
-        sn += [str(shortnames[i],"ascii")]
+        sn += [bytes_to_ascii(shortnames[i])]
 
     dll.calc_expected_data_net_only.restype = ctypes.c_int
     expected_names_no = ctypes.POINTER(ctypes.c_char_p)()
     expected_names_no_length = dll.calc_expected_data_net_only(calculation,ctypes.byref(expected_names_no))
-    expected_names_no = [str(x,"ascii") for x in expected_names_no[0:expected_names_no_length]]
+    expected_names_no = [bytes_to_ascii(x) for x in expected_names_no[0:expected_names_no_length]]
     print("expected names net only:",expected_names_no)
     
     net_definition(net)

--- a/sDNA/sdna_vs2008/tests/debug_test.py
+++ b/sDNA/sdna_vs2008/tests/debug_test.py
@@ -9,7 +9,7 @@ class my_void_p(ctypes.c_void_p):
     pass
 
 sdnadll = os.environ["sdnadll"]
-# print(f'{sdnadll=}')
+
 dll = ctypes.windll.LoadLibrary(sdnadll)
 
 dll.run_unit_tests()


### PR DESCRIPTION
Fixes issue #13.  See that issue for the answer to "Why on earth are you backporting to Python 2 when we're pushing towards Python 3?"

Output with this patch, from running (in \sdna_plus\sDNA\sdna_vs2008\tests, with Python 2 with numpy installed):

```
set "SDNADLL=c:\Program Files (x86)\sDNA\x64\sdna_vs2008.dll" & python -u debug_test.py
```


(thousands of lines ommitted - the point is the test script runs without encountering errors, in Python 2 just the same as it does on Python 3):
```
Junctions R12                      2  0  0  0
Connectivity R12                   6  0  0  0
SumGeoLen Euc R12                  4  6  33.3333  33.3333
MeanGeoLen Euc R12                 4  6  33.3333  33.3333
Sum Crow Flight R12                1.94365  1.94365  33.3333  33.3333
Mean Crow Flight R12               1.94365  1.94365  33.3333  33.3333
Diversion Ratio Euc R12            2.05798  3.08697  1  1
Convex Hull Area R12               8.5  17.5  0  0
Convex Hull Perimeter R12          13.8863  22.2161  200  200
Convex Hull Max Radius R12         3.16228  9  50  50
Convex Hull Bearing R12            108.435  270  180  270
Convex Hull Shape Index R12        1.80529  2.24434  inf  inf
Problem route weight R12           0  0  0  0
Problem route excess R12           0  0  0  0
Sum Euc Dist R20                   4  6  33.3333  33.3333
Mean Euc Dist R20                  4  6  33.3333  33.3333
NetQuantPD Euc R20                 0.25  0.166667  0.03  0.03
Betweenness Euc R20                0.333333  0.333333  0.333333  0.333333
TPBetweenness Euc R20              0.333333  0.333333  0.333333  0.333333
TPDestination R20                  1  1  1  1
Links R20                          1  1  1  1
Length R20                         12  18  100  100
Ang Dist R20                       810  270  0  0
Weight R20                         1  1  1  1
Junctions R20                      2  2  0  0
Connectivity R20                   6  6  0  0
SumGeoLen Euc R20                  4  6  33.3333  33.3333
MeanGeoLen Euc R20                 4  6  33.3333  33.3333
Sum Crow Flight R20                1.94365  1.94365  33.3333  33.3333
Mean Crow Flight R20               1.94365  1.94365  33.3333  33.3333
Diversion Ratio Euc R20            2.05798  3.08697  1  1
Convex Hull Area R20               8.5  17.5  0  0
Convex Hull Perimeter R20          13.8863  22.2161  200  200
Convex Hull Max Radius R20         3.16228  9  50  50
Convex Hull Bearing R20            108.435  270  180  270
Convex Hull Shape Index R20        1.80529  2.24434  inf  inf
Problem route weight R20           0  0  0  0
Problem route excess R20           0  0  0  0
Sum Euc Dist R100                  19  21  33.3333  33.3333
Mean Euc Dist R100                 9.5  10.5  33.3333  33.3333
NetQuantPD Euc R100                0.316667  0.233333  0.03  0.03
Betweenness Euc R100               1.33333  1.33333  0.333333  0.333333
TPBetweenness Euc R100             0.666667  0.666667  0.333333  0.333333
TPDestination R100                 1  1  1  1
Links R100                         2  2  1  1
Length R100                        30  30  100  100
Ang Dist R100                      1080  1080  0  0
Weight R100                        2  2  1  1
Junctions R100                     2  2  1  1
Connectivity R100                  6  6  3  3
SumGeoLen Euc R100                 19  21  33.3333  33.3333
MeanGeoLen Euc R100                9.5  10.5  33.3333  33.3333
Sum Crow Flight R100               9.22376  9.22376  33.3333  33.3333
Mean Crow Flight R100              4.61188  4.61188  33.3333  33.3333
Diversion Ratio Euc R100           2.0592  2.57369  1  1
Convex Hull Area R100              25  25  0  0
Convex Hull Perimeter R100         24.3852  24.3852  200  200
Convex Hull Max Radius R100        8.24621  9.48683  50  50
Convex Hull Bearing R100           75.9638  251.565  180  270
Convex Hull Shape Index R100       1.89279  1.89279  inf  inf
Problem route weight R100          0  0  0  0
Problem route excess R100          0  0  0  0
Sum Euc Dist R126                  131  139  148.333  148.333
Mean Euc Dist R126                 32.75  34.75  49.4444  49.4444
NetQuantPD Euc R126                0.352381  0.267232  0.0648063  0.0648063
Betweenness Euc R126               3.33333  3.33333  2.33333  2.33333
TPBetweenness Euc R126             0.916667  0.916667  0.694444  0.694444
TPDestination R126                 1.16667  1.16667  0.833333  0.833333
Links R126                         4  4  3  3
Length R126                        230  230  130  130
Ang Dist R126                      1080  1080  1080  1080
Weight R126                        4  4  3  3
Junctions R126                     2  2  2  2
Connectivity R126                  6  6  6  6
SumGeoLen Euc R126                 131  139  148.333  148.333
MeanGeoLen Euc R126                32.75  34.75  49.4444  49.4444
Sum Crow Flight R126               114.272  106.125  136.175  132.44
Mean Crow Flight R126              28.5679  26.5313  45.3918  44.1468
Diversion Ratio Euc R126           1.56273  1.89715  1.07915  1.1121
Convex Hull Area R126              5407.5  5407.5  525  172.5
Convex Hull Perimeter R126         355.085  355.085  214.884  213.047
Convex Hull Max Radius R126        103.005  100.404  53.2353  55.0818
Convex Hull Bearing R126           90.5563  354.857  174.611  273.122
Convex Hull Shape Index R126       1.85549  1.85549  6.99904  20.9389
Problem route weight R126          0  0  0  0
Problem route excess R126          0  0  0  0


destroying
done
```