### PR TITLE
Backport partial_test.py to python 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ UpgradeLog*.htm
 .vscode
 vcpkg_installed
 output/
+*testout*
+sDNA/sdna_vs2008/tests/odtest.*
+sDNA/sdna_vs2008/tests/regtestresids_py3.*
+sDNA/sdna_vs2008/tests/tinypred_py3.*
+sDNA/sdna_vs2008/tests/geom_test_py3.txt

--- a/sDNA/sdna_vs2008/tests/partial_test.py
+++ b/sDNA/sdna_vs2008/tests/partial_test.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
+
 import ctypes
 import sys,os
+
 
 # http://stackoverflow.com/questions/17840144/why-does-setting-ctypes-dll-function-restype-c-void-p-return-long
 class my_void_p(ctypes.c_void_p):
@@ -131,7 +134,7 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
                                                            warning_callback)
 
     if not calculation:
-        print ("config failed")
+        print("config failed")
         return
     
     dll.icalc_get_all_output_names.restype = ctypes.POINTER(ctypes.c_char_p)
@@ -147,16 +150,16 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
     net_definition(net)
     
     if not dll.calc_run(calculation):
-        print ("run failed")
+        print("run failed")
         return
 
     dll.net_print(net)
     
     
-    print ('\nshortnames: '+','.join([bytes_to_ascii(x) for x in sn]))
-    print ('created output buffer size float *',outlength)
+    print('\nshortnames: '+','.join([bytes_to_ascii(x) for x in sn]))
+    print('created output buffer size float *',outlength)
 
-    print ('\nOUTPUT DATA:')
+    print('\nOUTPUT DATA:')
 
     # for debug display we want to invert output arrays
     out_buffer_type = ctypes.c_float * outlength
@@ -167,33 +170,33 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
         out_array += [list(out_buffer)]
 
     for i in range(outlength):
-        print (names[i]+' '*(35-len(names[i]))+'  '.join("%.6g"%link_data[i] for link_data in out_array))
+        print(names[i]+' '*(35-len(names[i]))+'  '.join("%.6g"%link_data[i] for link_data in out_array))
 
-    print ()
-    print ('destroying')
+    print()
+    print('destroying')
     dll.net_destroy(net)
     dll.calc_destroy(calculation)
-    print ('done')
-    print ()
+    print('done')
+    print()
     
 def test_net_all_options(test_name,net_definition,euclidean_radii,problink,extra_config):
-    print ("%s, Angular analysis, discrete space, unweighted"%test_name)
+    print("%s, Angular analysis, discrete space, unweighted"%test_name)
     test_net(net_definition,euclidean_radii,ANGULAR,False,False,problink,extra_config)
-    print ("\n\n%s, Angular analysis, cont space, unweighted"%test_name)
+    print("\n\n%s, Angular analysis, cont space, unweighted"%test_name)
     test_net(net_definition,euclidean_radii,ANGULAR,True,False,problink,extra_config)
 
 def bigger_test(extra_config):
     test_net_all_options("Choice Test",choice_test,choice_test_radii,12,extra_config)
-    print ("Junction cost test")
+    print("Junction cost test")
     test_net(junction_cost_test,junction_cost_test_radii,EUCLIDEAN,False,False,1,extra_config)
-    print ("Split link test")
+    print("Split link test")
     test_net(split_link_test,split_link_test_radii,EUCLIDEAN,False,False,1,extra_config)
-    print ("Activity weight test")
+    print("Activity weight test")
     test_net(act_weight_test,act_weight_test_radii,EUCLIDEAN,False,False,10,extra_config)
     test_net_all_options("Global Radius Only Test",choice_test,["n"],12,extra_config)
-    print ("Nasty link test")
+    print("Nasty link test")
     test_net(nasty_link_test,nasty_link_test_radii,ANGULAR,False,False,1,extra_config)
-    print ("Triangle stick test")
+    print("Triangle stick test")
     test_net(triangle_stick_test,triangle_stick_test_radii,EUCLIDEAN,False,False,1,extra_config)
     
 bigger_test("linkonly")

--- a/sDNA/sdna_vs2008/tests/partial_test.py
+++ b/sDNA/sdna_vs2008/tests/partial_test.py
@@ -14,6 +14,14 @@ dll = ctypes.windll.LoadLibrary(os.environ["sdnadll"])
 
 current_net_arcids = None
 
+
+def bytes_to_ascii(x):
+    """ Python 2 compatible replacement for str(x, 'ascii').
+        str accepts one argument only, in Python 2.  
+    """
+    return x.decode('ascii')
+
+
 # dummy progress bar callback func
 CALLBACKFUNCTYPE = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_long)
 def set_progressor(x):
@@ -21,7 +29,7 @@ def set_progressor(x):
 set_progressor_callback = CALLBACKFUNCTYPE(set_progressor)
 WARNINGCALLBACKFUNCTYPE = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p)
 def warning(x):
-    print(str(x,"ascii"))
+    print(bytes_to_ascii(x))
     return 0
 warning_callback = WARNINGCALLBACKFUNCTYPE(warning)
 
@@ -129,7 +137,7 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
     dll.icalc_get_all_output_names.restype = ctypes.POINTER(ctypes.c_char_p)
     dll.icalc_get_output_length.restype = ctypes.c_int
     outlength = dll.icalc_get_output_length(calculation)
-    names = [str(x,"ascii") for x in dll.icalc_get_all_output_names(calculation)[0:outlength]]
+    names = [bytes_to_ascii(x) for x in dll.icalc_get_all_output_names(calculation)[0:outlength]]
     dll.icalc_get_short_output_names.restype = ctypes.POINTER(ctypes.c_char_p)
     shortnames = dll.icalc_get_short_output_names(calculation)
     sn=[]
@@ -145,7 +153,7 @@ def test_net(net_definition,euclidean_radii,analysis_type,cont_space,length_weig
     dll.net_print(net)
     
     
-    print ('\nshortnames: '+','.join([str(x,"ascii") for x in sn]))
+    print ('\nshortnames: '+','.join([bytes_to_ascii(x) for x in sn]))
     print ('created output buffer size float *',outlength)
 
     print ('\nOUTPUT DATA:')


### PR DESCRIPTION
Same justification and fix, as for Issue #13 and PR #14 (this does the same to partial_test.py, as those did for debug_test.py)

Fix:
adds:
```
def bytes_to_ascii(x):
    """ Python 2 compatible replacement for str(x, 'ascii').
        str accepts one argument only, in Python 2.  
    """
    return x.decode('ascii')
```

and replace all `str(x, 'ascii')` with `bytes_to_ascii(x)`

The sDNA manual states it has been tested on Python 2.7 and 2.6.  Running this particular test in Python 2.7 as it is fails, but fails due to a TypeError in the test code:

```
(pytest_numpy_py27) c:\...\repos\sdna_plus\sDNA\sdna_vs2008\tests\pytest>set "sdnadll=c:\Program Files (x86)\sDNA\x64\sdna_vs2008.dll" & python -u ..\partial_test.py
Choice Test, Angular analysis, discrete space, unweighted
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 315, in 'calling callback function'
  File "..\partial_test.py", line 24, in warning
    print(str(x,"ascii"))
TypeError: str() takes at most 1 argument (2 given)
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 315, in 'calling callback function'
  File "..\partial_test.py", line 24, in warning
    print(str(x,"ascii"))
TypeError: str() takes at most 1 argument (2 given)
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 315, in 'calling callback function'
  File "..\partial_test.py", line 24, in warning
    print(str(x,"ascii"))
TypeError: str() takes at most 1 argument (2 given)
Traceback (most recent call last):
  File "..\partial_test.py", line 191, in <module>
    bigger_test("linkonly")
  File "..\partial_test.py", line 178, in bigger_test
    test_net_all_options("Choice Test",choice_test,choice_test_radii,12,extra_config)
  File "..\partial_test.py", line 173, in test_net_all_options
    test_net(net_definition,euclidean_radii,ANGULAR,False,False,problink,extra_config)
  File "..\partial_test.py", line 132, in test_net
    names = [str(x,"ascii") for x in dll.icalc_get_all_output_names(calculation)[0:outlength]]
TypeError: str() takes at most 1 argument (2 given)
```

Behaviour with this PR applied (the same as it currently is when the test is run in Python 3.12)
```
(pytest_numpy_py27) C:\...\sdna_plus\sDNA\sdna_vs2008\tests\pytest>set "sdnadll=c:\Program Files (x86)\sDNA\x64\sdna_vs2008.dll" & python -u ..\partial_test.py
Choice Test, Angular analysis, discrete space, unweighted
WARNING: custommetric was supplied but is not being used
Using default of angular link centres for angular analysis
Using xytolerance=0, ztolerance=0
sDNA is running in 64-bit mode
Building network and checking for tolerance errors...
Polyline 10 id=0
    Points: (0,3) (0,0) (1,0) (1,1) (2,1) (2,0) (3,0) (3,1) (4,1) (4,0) (5,0)
    edge 0 (s10+), conn: 3(ang90) 6(ang0)
    edge 1 (s10-), conn: 2(ang90) 4(ang0)

...

Convex Hull Max Radius Rn          1.80278  2  1.5  1.5
Convex Hull Bearing Rn             56.3099  270  90  270
Convex Hull Shape Index Rn         1.66669  1.66669  inf  inf
()
destroying
done
()
```

