### PR TITLE
Compile sDNA in a windows GitHub action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,10 +3,10 @@ name: "Compile with MSBuild and VS 2022 for Windows"
 on:
   workflow_dispatch:
   push:
-    branches: [ "Compile_sDNA_in_a_Windows_Github_Action" ]
+    branches: [ "main" ]
 
   # pull_request:
-  #   branches: [ "Compile_sDNA_in_a_Windows_Github_Action" ]
+  #   branches: [ "main" ]
 
 env:
   CONFIGURATION: Release

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,130 @@
+name: "Compile with MSBuild and VS 2022 for Windows"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "Compile_sDNA_in_a_Windows_Github_Action" ]
+
+  # pull_request:
+  #   branches: [ "Compile_sDNA_in_a_Windows_Github_Action" ]
+
+env:
+  CONFIGURATION: Release
+  PLATFORM: x64
+  OSGEO4W_GEOS_URL: https://download.osgeo.org/osgeo4w/v2/x86_64/release/geos
+  GEOS_VERSION: '3.12.0-1'
+  RELEASE: '4.1.1'
+  BOOST_VERSION: '1.8.3'
+
+
+jobs:
+  compile:
+    name: Try to compile on windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+
+
+
+
+    - name: 'Add "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\bin" to path'
+      shell: bash
+      run: echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\bin" >> $GITHUB_PATH
+
+    - name: Deploy Advinst
+      uses: caphyon/advinst-github-action@v1.1
+      with:
+        advinst-version: '21.3'
+
+        # advinst-license: ${{ secrets.ADVINST_LICENSE_KEY }}
+        # " advinst-license
+        # Advanced Installer license ID. This parameter is optional if you are using a simple project type.
+        # "
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Integrate vcpkg with Visual Studio
+      run: vcpkg integrate install
+
+
+    - name: Restore Cache'd Geos binary
+      id: cache-geos-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ${{ github.workspace }}\output\${{ env.CONFIGURATION }}\${{ env.PLATFORM }}\geos_c.dll
+        key: ${{ runner.os }}-geos_v${{ env.GEOS_VERSION }}
+
+    - name: Download and unzip Geos binary from OSGEO
+      if: steps.cache-geos-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        GEOS_FILE=geos-${{ env.GEOS_VERSION }}.tar.bz2
+        curl -L -o $GEOS_FILE ${{ env.OSGEO4W_GEOS_URL }}/$GEOS_FILE
+        tar -xf $GEOS_FILE
+        BUILD_CONFIG=${{ env.CONFIGURATION }}
+        mv bin/geos_c.dll $GITHUB_WORKSPACE/output/${BUILD_CONFIG,R}/${{ env.PLATFORM }}
+      # ${BUILD_CONFIG,R} Tries to make first letter of BUILD_CONFIG lowercase only if it is an R
+      # as the sDNA source tree has output/Debug
+      #                             output/release
+      # But the corresponding supported configs are Debug and Release
+
+    - name: Cache Geos binary
+      if: steps.cache-geos-restore.outputs.cache-hit != 'true'
+      id: cache-geos-save
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ github.workspace }}\output\${{ env.CONFIGURATION }}\${{ env.PLATFORM }}\geos_c.dll
+        key: ${{ steps.cache-geos-restore.outputs.cache-primary-key }}
+
+    - name: Restore vcpkg Deps
+      id: cache-vcpkg-deps-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          C:\vcpkg\packages\
+          D:\a\sdna_plus\sdna_plus\vcpkg_installed\
+        key: ${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+
+    # Let vcpkg do its thing with the cache and don't skip this step
+    # if there is a cache hit. Vcpkg will detect pre existing files.
+    # that it previously installed.
+    - name: Install Boost from vcpkg.json
+      run: vcpkg install
+
+
+    - name: Cache vcpkg Deps
+      if: steps.cache-vcpkg-deps-restore.outputs.cache-hit != 'true'
+      id: cache-deps-save
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          C:\vcpkg\packages\
+          D:\a\sdna_plus\sdna_plus\vcpkg_installed\
+        key: ${{ steps.cache-vcpkg-deps-restore.outputs.cache-primary-key }}
+
+
+    - name: Build sDNA
+      working-directory: ${{ github.workspace }}
+      run: > 
+        msbuild build_installer.proj 
+        /t:rebuild 
+        /p:Platform=${{ env.PLATFORM }}  
+        /p:Configuration=${{ env.CONFIGURATION }} 
+        /p:VcpkgEnableManifest=true
+
+    # - name: Package sDNA
+    #   shell: cmd
+    #   run: |
+    #     mkdir release_zip_files_dir
+    #     cd release_zip_files_dir
+    #     ..\package_release.bat
+
+    - name: upload output dir
+      uses: actions/upload-artifact@v4
+      with:
+        name: sDNA_plus_v${{ env.RELEASE }}_${{ env.PLATFORM }}_${{ env.CONFIGURATION }}_osgeo4w_geos_v${{ env.GEOS_VERSION }}_Boost_v${{ env.BOOST_VERSION }}_RTTI_on
+        # path: output/release
+        path: sDNA_setup_win_v*.msi

--- a/build_installer.proj
+++ b/build_installer.proj
@@ -5,9 +5,9 @@
 
         <MSBuild Projects="build_output.proj" Targets="Rebuild"/>
 
-        <Exec Command="&quot;C:\Program Files (x86)\Caphyon\Advanced Installer 21.3\bin\x86\AdvancedInstaller.com&quot; /build installerbits\advanced\sdna.aip"/>
+        <Exec Command="&quot;AdvancedInstaller.com&quot; /build installerbits\advanced\sdna.aip"/>
     
-        <Exec Command="c:\Python27\ArcGIS10.8\python.exe -u installerbits\rename_version.py installerbits/advanced/output/sdna_setup.msi ."/>
+        <Exec Command="python -u installerbits\rename_version.py installerbits/advanced/output/sdna_setup.msi ."/>
 
     </Target>
 

--- a/getSdnaVersion.py
+++ b/getSdnaVersion.py
@@ -3,8 +3,8 @@ import re,os
 def getVersion():
     version = None
     versionfile = os.path.dirname(__file__)+os.sep+"sDNA"+os.sep+"sdna_vs2008"+os.sep+"version_template.h"
-    for line in (open (versionfile)):
-        m = re.match('^const char \*SDNA_VERSION = "(.*)";.*',line)
+    for line in (open (versionfile, 'rt')):
+        m = re.match(r'^const char \*SDNA_VERSION = "(.*)";.*',line)
         if m:
             assert (version==None)
             version = m.group(1)

--- a/installerbits/_parentdir.py
+++ b/installerbits/_parentdir.py
@@ -1,7 +1,16 @@
 import sys,os
 
-encoding = sys.getfilesystemencoding()
-path = os.path.dirname(unicode(__file__, encoding))
+#  On Python 2 and earlier
+if sys.version_info.major <= 2:
+    encoding = sys.getfilesystemencoding()
+    path = os.path.dirname(unicode(__file__, encoding))
+else: 
+      # On Python 3 there is (and it can be assumed 
+      # in all future versions there will be) 
+      # native unicode support
+    path = os.path.dirname(__file__)
+
+
 parentdir = os.path.dirname(path)
 if parentdir not in sys.path:
     sys.path.insert(0,parentdir)

--- a/installerbits/rename_version.py
+++ b/installerbits/rename_version.py
@@ -1,16 +1,18 @@
+from __future__ import print_function
+
 import os,re,sys,_parentdir,shutil
 from getSdnaVersion import getVersion
 
 installfile,outputdir = sys.argv[1:3]
 
-print installfile
-print outputdir
+print(installfile)
+print(outputdir)
 
 version = getVersion()
 
-filename_friendly_version = re.sub("\.","_",version)
+filename_friendly_version = re.sub(r"\.","_",version)
 
-outfilename = "%s/sDNA_setup_win_v%s.msi"%(outputdir,filename_friendly_version)
+outfilename = os.path.join(outputdir, "sDNA_setup_win_v%s.msi" % filename_friendly_version)
 
 if (os.path.exists(outfilename)):
     os.unlink(outfilename)


### PR DESCRIPTION
This is a minimal set of code changes required to compile sDNA in a Github Action (on a Windows runner image, in Visual Studio 2022).

An installable .msi is produced (whereas before, everything was just zipped) , e.g.:  https://github.com/JamesParrott/sdna_plus/actions/runs/7958143893/artifacts/1256162962 (it's straightforward to change the file name in compile.yml - the verbose one was to record changes from previous compilation investigations)

Release/debug profiles are configurable.

The files in this PR were copied into a new branch based on this repo, from a downstream branch further developed from PR #22, (https://github.com/JamesParrott/sdna_plus/tree/CI_(Compile_and_test_in_a_Github_Action)).  So there will be no major merge conflicts if both PRs are accepted.  The goal is to enable both compilation and testing in sequence, as part of a Continuous Integration work flow.

Two hard-coded executable paths have been made generic.  So to compile locally (in an environment in which these paths are valid), with these necessary changes to build_installer.proj, AdvancedInstaller.com and a modern Python.exe must be added to %path%.

The python builder scripts do need updating to Python 3 anyway, but an alternative to the changes to the Python files would be to add to compile.yml:
```
    - uses: LizardByte/setup-python-action@master
      with:
        python-version: 2.7
```
This would avoid using the Github Actions Windows runner image's pre-installed Python 3s (but these scripts only rename and copy  /and delete files according to a regex, and have only core deps, so runnning them using a global system Python instead of a venv is no problem at all).

Commit [cae52f0](https://github.com/fiftysevendegreesofrad/sdna_plus/commit/cae52f08e6d85c0c7521557b1ef818d6b82c08d2) was tagged v4.1.1.  Tags are a standard way of kicking off release workflows, and can easily be included too.  Github are currently providing minutes on Action runners for free for open source projects, so build and testing on every commit and PR is also possible, wth the main impact of delaying the push of a commit.