### PR TITLE
Linux OpenMP build: single-command build_linux.sh + CMake fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ sDNA_setup*.msi
 build_cmake*/**/*
 build_output_cmake*/**/*
 build_output_hatch*/**/*
+build_linux/**/*
 /sDNA/sDNA_2022/x64
 sDNA/sdna_vs2008/sdna_vs2008.vcxproj.user
 output/Release/geos_c.dll

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ the Zig for Windows build (entirely optional) and the Linux builds.
 
 ##### Quick build (recommended)
 
-Tested on Ubuntu 26.04 and 24.04
+Tested on Ubuntu 26.04, 24.04, and on Debian Trixie.  On Ubuntu 24.04 and other older distros, see note below about adding Kitware's repositories for CMake >= 3.29
 
 ```bash
 # Install prerequisites (one-time, needs ~480 MB space)

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,6 @@ the Zig for Windows build (entirely optional) and the Linux builds.
 
 ##### Quick build (recommended)
 
-```bash
 Tested on Ubuntu 26.04 and 24.04
 
 ```bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,6 +18,7 @@ the Zig for Windows build (entirely optional) and the Linux builds.
 
 ##### Quick build (recommended)
 
+```bash
 On any modern Ubuntu/Debian system (20.04+):
 
 ```bash
@@ -25,10 +26,10 @@ On any modern Ubuntu/Debian system (20.04+):
 sudo apt update
 sudo apt install cmake make g++ libboost-dev python3 -y
 
-# Clone and build
+# Clone and build (build_linux.sh itself does NOT need root)
 git clone --depth=1 --branch=Cross_platform https://github.com/fiftysevendegreesofrad/sdna_plus
 cd sdna_plus
-sudo bash build_linux.sh
+bash build_linux.sh
 ```
 
 This produces `output/Release/x64/sdna_vs2008.so` with **OpenMP multi-threading** enabled,
@@ -43,7 +44,7 @@ To use with vcpkg for pinned Boost 1.83 (matching CI exactly):
 git clone --depth=1 https://github.com/microsoft/vcpkg ~/vcpkg
 cd ~/vcpkg && ./bootstrap-vcpkg.sh
 cd path/to/sdna_plus
-VCPKG_ROOT=~/vcpkg sudo bash build_linux.sh
+VCPKG_ROOT=~/vcpkg bash build_linux.sh
 ```
 
 ##### Manual CMake build
@@ -51,6 +52,7 @@ VCPKG_ROOT=~/vcpkg sudo bash build_linux.sh
 If you prefer to run the steps individually:
 
 ```bash
+# Prerequisites (needs root); the build steps below do not
 sudo apt install cmake make g++ libboost-dev
 
 # Create a stub vcpkg (or use real vcpkg)

--- a/BUILD.md
+++ b/BUILD.md
@@ -79,7 +79,7 @@ sudo apt-get install r-cran-optparse r-cran-sjstats
 
 Run a smoke test:
 ```bash
-export SDNADLL=$(pwd)/output/Release/x64/sdna_vs2008.so
+export sdnadll=$(pwd)/output/Release/x64/sdna_vs2008.so
 cd sDNA/sdna_vs2008/tests
 python3 prepare_test_new.py
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -37,7 +37,16 @@ no vcpkg required.
 
 The script works on Ubuntu 24.04 through 26.04, and Debian 13+.
 Tested with GCC 10–15 and Boost 1.71–1.90.
+###### Installing CMake on Debian based distros, if >= 3.29 unavailable in default apt repos
+Follow [the instructions](https://apt.kitware.com/) to configure your package manager (apt)
+to download directly from Kitware's CMake apt repository.  E.g. on Ubuntu 24.04:
 
+```bash
+        sudo apt update &&
+        sudo apt install -y ca-certificates gpg wget &&
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null &&
+        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | tee /etc/apt/sources.list.d/kitware.list &&
+        sudo apt update
 To use with vcpkg for pinned Boost 1.83 (matching CI exactly):
 ```bash
 git clone --depth=1 https://github.com/microsoft/vcpkg ~/vcpkg

--- a/BUILD.md
+++ b/BUILD.md
@@ -22,7 +22,8 @@ On any modern Ubuntu/Debian system (20.04+):
 
 ```bash
 # Install prerequisites (one-time)
-sudo apt install cmake make g++ libboost-dev python3
+sudo apt update
+sudo apt install cmake make g++ libboost-dev python3 -y
 
 # Clone and build
 git clone --depth=1 --branch=Cross_platform https://github.com/fiftysevendegreesofrad/sdna_plus

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,42 +15,72 @@ produce an x64 output installation.
 the Zig for Windows build (entirely optional) and the Linux builds.
 
 #### Building locally on Linux 
-##### Ubuntu 22.04 (Jammy)
-Kitware haven't got a repo for Noble (24.04) yet, so 22.04 is needed for now.
-[Upgrade CMake to 3.29](https://askubuntu.com/a/1157132)
-Working directory assumed to be `/root`
-* `sudo apt purge --auto-remove cmake`
-* `wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null`
-* `sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main'`
-* `sudo apt update`
-* `sudo apt-get install curl zip unzip tar g++ python-is-python3 python3-pip python3-venv cmake ninja-build `
-* `git clone --depth=1 http://www.github.com/Microsoft/vcpkg`
-* `cd vcpkg`
-* `./bootstrap-vcpkg.sh`
-On ARM:
-* `export VCPKG_FORCE_SYSTEM_BINARIES=1`
-* `cd ..`
-* `git clone --depth=1 --branch=Cross_platform  http://www.github.com/fiftysevendegreesofrad/sdna_plus`
-Download GEOS 3.3.5 and compile it locally (so that it can link to your available version of glibc, instead of whichever one was in the build environment I used).  `.github\workflows\build_geos.yml` can be used in a Github Action Ubuntu runner.
-* `curl -OL http://download.osgeo.org/geos/geos-3.3.5.tar.bz2`
-* `tar xfj geos-3.3.5.tar.bz2`
-* `cd geos-3.3.5`
-* `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/root/build_geos/_installed -DBUILD_SHARED_LIBS=ON -DBUILD_DOCUMENTATION=OFF -DBUILD_TESTING=OFF -G Ninja -B /root/build_geos -S .`
-* `cmake --build /root/build_geos`
-* `cp /root/build_geos/lib/libgeos_c.so /root/sdna_plus/sDNA/geos/x64/src`
-Then pick one of the following package options
-###### Simple output dir 
-The `output/Config` dir is automatically zipped if it was built in one of the Github Actions workflows, 
-e.g. `.github\workflows\smoke_test_gcc.yml`
-* `cd sdna_plus`
-* `VCPKG_INSTALLATION_ROOT=/root/vcpkg cmake -G "Ninja Multi-Config" -D USE_ZIG=OFF -D CMAKE_MAKE_PROGRAM=/usr/bin/ninja -D BUNDLE_PYSHP=ON -B build_linux -S .`
-* `cmake --build build_linux --config=Release`
-Install user-land dependencies (R).
-* `sudo apt-get install r-cran-optparse r-cran-sjstats`
-Run a smoke test
-* `export sdnadll=/root/sdna_plus/output/Release/x64/sdna_vs2008.so`
-* `cd sDNA/sdna_vs2008/tests`
-* `python prepare_test_new.py`
+
+##### Quick build (recommended)
+
+On any modern Ubuntu/Debian system (20.04+):
+
+```bash
+# Install prerequisites (one-time)
+sudo apt install cmake make g++ libboost-dev python3
+
+# Clone and build
+git clone --depth=1 --branch=Cross_platform https://github.com/fiftysevendegreesofrad/sdna_plus
+cd sdna_plus
+sudo bash build_linux.sh
+```
+
+This produces `output/Release/x64/sdna_vs2008.so` with **OpenMP multi-threading** enabled,
+and bundles `libgeos_c.so` for spatial operations. All dependencies come from system packages —
+no vcpkg required.
+
+The script works on Ubuntu 20.04 through 26.04, and Debian 11+.
+Tested with GCC 10–15 and Boost 1.71–1.90.
+
+To use with vcpkg for pinned Boost 1.83 (matching CI exactly):
+```bash
+git clone --depth=1 https://github.com/microsoft/vcpkg ~/vcpkg
+cd ~/vcpkg && ./bootstrap-vcpkg.sh
+cd path/to/sdna_plus
+VCPKG_ROOT=~/vcpkg sudo bash build_linux.sh
+```
+
+##### Manual CMake build
+
+If you prefer to run the steps individually:
+
+```bash
+sudo apt install cmake make g++ libboost-dev
+
+# Create a stub vcpkg (or use real vcpkg)
+mkdir -p /tmp/sdna_vcpkg_stub/scripts/buildsystems
+echo 'set(VCPKG_MANIFEST_MODE OFF)' > /tmp/sdna_vcpkg_stub/scripts/buildsystems/vcpkg.cmake
+
+# Configure and build
+VCPKG_ROOT=/tmp/sdna_vcpkg_stub cmake -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release -DUSE_ZIG=OFF -DBUNDLE_PYSHP=OFF \
+    -B build_linux -S .
+cmake --build build_linux --parallel $(nproc)
+
+# Copy outputs manually (post-build copy uses multi-config paths)
+mkdir -p output/Release/x64 output/Release/bin
+cp build_linux/sDNA/sdna_vs2008/sdna_vs2008.so output/Release/x64/
+cp sDNA/geos/x64/src/libgeos_c.so output/Release/x64/
+cp -r arcscripts/* output/Release/
+cp -r arcscripts/bin/* output/Release/bin/
+```
+
+Install user-land dependencies (R, required for sDNA Learn/Predict):
+```bash
+sudo apt-get install r-cran-optparse r-cran-sjstats
+```
+
+Run a smoke test:
+```bash
+export SDNADLL=$(pwd)/output/Release/x64/sdna_vs2008.so
+cd sDNA/sdna_vs2008/tests
+python3 prepare_test_new.py
+```
 Run all regression tests:
 If this isn't a throw away env, make a venv and activate it.
 * `python -m pip install pytest`

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,7 +19,7 @@ the Zig for Windows build (entirely optional) and the Linux builds.
 ##### Quick build (recommended)
 
 ```bash
-On any modern Ubuntu/Debian system (20.04+):
+Tested on Ubuntu 26.04 and 24.04
 
 ```bash
 # Install prerequisites (one-time, needs ~480 MB space)

--- a/BUILD.md
+++ b/BUILD.md
@@ -21,7 +21,7 @@ the Zig for Windows build (entirely optional) and the Linux builds.
 On any modern Ubuntu/Debian system (20.04+):
 
 ```bash
-# Install prerequisites (one-time)
+# Install prerequisites (one-time, needs ~480 MB space)
 sudo apt update
 sudo apt install cmake make g++ libboost-dev python3 -y
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,7 +35,7 @@ This produces `output/Release/x64/sdna_vs2008.so` with **OpenMP multi-threading*
 and bundles `libgeos_c.so` for spatial operations. All dependencies come from system packages —
 no vcpkg required.
 
-The script works on Ubuntu 20.04 through 26.04, and Debian 11+.
+The script works on Ubuntu 24.04 through 26.04, and Debian 13+.
 Tested with GCC 10–15 and Boost 1.71–1.90.
 
 To use with vcpkg for pinned Boost 1.83 (matching CI exactly):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ elseif (NOT MSVC)
     set(CMAKE_CXX_COMPILER "g++")
 endif()
 
-if (IS_READABLE ENV{VCPKG_ROOT})
+if (IS_READABLE "$ENV{VCPKG_ROOT}")
     SET(VCPKG_ROOT 
     "$ENV{VCPKG_ROOT}"
     )

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ bash build_linux.sh
 ```
 
 This produces `output/Release/x64/sdna_vs2008.so` with OpenMP enabled.
-Then set `export SDNADLL=$(pwd)/output/Release/x64/sdna_vs2008.so` before running sDNA commands.
+Then set `export sdnadll=$(pwd)/output/Release/x64/sdna_vs2008.so` before running sDNA commands.
 
 CMake 3.29 is required.  See [BUILD.md](BUILD.md) for detailed build instructions, including guidance for installing later versions of CMake on older distros.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bash build_linux.sh
 This produces `output/Release/x64/sdna_vs2008.so` with OpenMP enabled.
 Then set `export SDNADLL=$(pwd)/output/Release/x64/sdna_vs2008.so` before running sDNA commands.
 
-See [BUILD.md](BUILD.md) for detailed build instructions.
+CMake 3.29 is required.  See [BUILD.md](BUILD.md) for detailed build instructions, including guidance for installing later versions of CMake on older distros.
 
 #### Using R Portable 3.2.3 (Windows only). 
 This is the same [R-Portable](https://github.com/JamesParrott/rportable) as bundled 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pipx install sdna_plus[learn]
 sudo apt install cmake make g++ libboost-dev python3
 git clone --depth=1 --branch=Cross_platform https://github.com/fiftysevendegreesofrad/sdna_plus
 cd sdna_plus
-sudo bash build_linux.sh
+bash build_linux.sh
 ```
 
 This produces `output/Release/x64/sdna_vs2008.so` with OpenMP enabled.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ pipx install sdna_plus[learn]
 
 ##### Building from source (with OpenMP multi-threading)
 
-The pip wheel is built without OpenMP. For multi-threaded performance, build from source:
 
 ```bash
 sudo apt install cmake make g++ libboost-dev python3

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ sudo apt-get install -y r-cran-optparse r-cran-sjstats
 pipx install sdna_plus[learn]
 ```
 
+##### Building from source (with OpenMP multi-threading)
+
+The pip wheel is built without OpenMP. For multi-threaded performance, build from source:
+
+```bash
+sudo apt install cmake make g++ libboost-dev python3
+git clone --depth=1 --branch=Cross_platform https://github.com/fiftysevendegreesofrad/sdna_plus
+cd sdna_plus
+sudo bash build_linux.sh
+```
+
+This produces `output/Release/x64/sdna_vs2008.so` with OpenMP enabled.
+Then set `export SDNADLL=$(pwd)/output/Release/x64/sdna_vs2008.so` before running sDNA commands.
+
+See [BUILD.md](BUILD.md) for detailed build instructions.
+
 #### Using R Portable 3.2.3 (Windows only). 
 This is the same [R-Portable](https://github.com/JamesParrott/rportable) as bundled 
 with sDNA previously.  Requires ~100MB.

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -173,7 +173,7 @@ if [ -f "${SO_FILE}" ]; then
 
     echo ""
     echo "Quick test:"
-    echo "  export SDNADLL=\"${SO_FILE}\""
+    echo "  export sdnadll=\"${SO_FILE}\""
     echo "  cd sDNA/sdna_vs2008/tests"
     echo "  python3 prepare_test_new.py"
     echo ""

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build_linux.sh — Single-command Linux build for sDNA+
+# Produces output/Release/x64/sdna_vs2008.so with OpenMP support
+#
+# Usage:
+#   sudo bash build_linux.sh
+#
+# Prerequisites are checked automatically. On a fresh Ubuntu/Debian system:
+#   sudo apt install cmake make g++ libboost-dev python3
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build_linux"
+OUTPUT_DIR="${SCRIPT_DIR}/output/Release/x64"
+STUB_VCPKG_ROOT="/tmp/sdna_vcpkg_stub"
+
+echo "========================================"
+echo " sDNA+ Linux Build (with OpenMP)"
+echo "========================================"
+echo ""
+
+# ---- Check prerequisites ----
+MISSING=""
+for cmd in cmake g++ make; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "  MISSING: $cmd"
+        MISSING="$MISSING $cmd"
+    fi
+done
+
+if [ -n "$MISSING" ]; then
+    echo ""
+    echo "ERROR: Required tools not found:$MISSING"
+    echo "Install with: sudo apt install cmake make g++ libboost-dev python3"
+    exit 1
+fi
+
+# Check for Boost headers
+if [ ! -d /usr/include/boost ]; then
+    echo "ERROR: Boost headers not found at /usr/include/boost"
+    echo "Install with: sudo apt install libboost-dev"
+    exit 1
+fi
+
+echo "Prerequisites OK (cmake, g++, make, boost)"
+echo ""
+
+# ---- Set up vcpkg toolchain stub ----
+# The project CMake requires a vcpkg toolchain file.
+# If VCPKG_ROOT is set and contains a real vcpkg, use it (pins Boost 1.83).
+# Otherwise, create a stub that uses system packages.
+if [ -n "${VCPKG_ROOT:-}" ] && [ -f "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" ]; then
+    echo "Using vcpkg from VCPKG_ROOT=${VCPKG_ROOT}"
+    export VCPKG_ROOT
+else
+    echo "No vcpkg found — using system Boost and packages"
+    export VCPKG_ROOT="${STUB_VCPKG_ROOT}"
+    mkdir -p "${VCPKG_ROOT}/scripts/buildsystems"
+    cat > "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" << 'VCPKG_EOF'
+# Stub vcpkg toolchain — use system packages (Boost, etc.)
+if(NOT DEFINED VCPKG_TARGET_TRIPLET)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+        set(VCPKG_TARGET_TRIPLET "x64-linux")
+    else()
+        set(VCPKG_TARGET_TRIPLET "arm64-linux")
+    endif()
+endif()
+set(VCPKG_MANIFEST_MODE OFF)
+message(STATUS "Using stub vcpkg toolchain (system packages)")
+VCPKG_EOF
+fi
+
+# ---- Clean previous build ----
+rm -rf "${BUILD_DIR}"
+
+# ---- Configure ----
+echo ""
+echo "=== Configuring (Unix Makefiles, Release) ==="
+cmake -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_ZIG=OFF \
+    -DBUNDLE_PYSHP=OFF \
+    -DCMAKE_MAKE_PROGRAM="$(command -v make)" \
+    -B "${BUILD_DIR}" \
+    -S "${SCRIPT_DIR}"
+
+# ---- Build ----
+echo ""
+echo "=== Building (parallel: $(nproc) jobs) ==="
+cmake --build "${BUILD_DIR}" --parallel "$(nproc)" 2>&1 || {
+    # The .so may have built but post-build copy failed (Unix Makefiles
+    # path mismatch with CMAKE_CONFIGURATION_TYPES override). Check.
+    if [ -f "${BUILD_DIR}/sDNA/sdna_vs2008/sdna_vs2008.so" ]; then
+        echo ""
+        echo "NOTE: .so built but post-build copy failed (expected with Unix Makefiles generator)."
+        echo "      Assembling output by hand..."
+    else
+        echo ""
+        echo "BUILD FAILED — see errors above"
+        exit 1
+    fi
+}
+
+# ---- Assemble output directory ----
+echo ""
+echo "=== Assembling output/Release/x64/ ==="
+mkdir -p "${OUTPUT_DIR}"
+
+# Copy the sDNA shared library
+SO_SRC="${BUILD_DIR}/sDNA/sdna_vs2008/sdna_vs2008.so"
+if [ -f "${SO_SRC}" ]; then
+    cp -v "${SO_SRC}" "${OUTPUT_DIR}/"
+else
+    echo "ERROR: sdna_vs2008.so not found at ${SO_SRC}"
+    exit 1
+fi
+
+# Copy geos shared library (pre-built, in-tree)
+GEOS_SRC="${SCRIPT_DIR}/sDNA/geos/x64/src/libgeos_c.so"
+if [ -f "${GEOS_SRC}" ]; then
+    cp -v "${GEOS_SRC}" "${OUTPUT_DIR}/"
+else
+    echo "WARNING: libgeos_c.so not found at ${GEOS_SRC} — geos functions may fail"
+fi
+
+# Copy Python scripts
+echo "Copying Python scripts..."
+rsync -a --exclude='__pycache__' "${SCRIPT_DIR}/arcscripts/" "${SCRIPT_DIR}/output/Release/" 2>/dev/null || \
+    cp -r "${SCRIPT_DIR}/arcscripts/"* "${SCRIPT_DIR}/output/Release/" 2>/dev/null || true
+
+# Copy bin scripts to bin subdirectory
+mkdir -p "${SCRIPT_DIR}/output/Release/bin"
+cp -r "${SCRIPT_DIR}/arcscripts/bin/"* "${SCRIPT_DIR}/output/Release/bin/" 2>/dev/null || true
+
+# Copy installer bits
+cp "${SCRIPT_DIR}/installerbits/license.rtf" "${SCRIPT_DIR}/output/Release/" 2>/dev/null || true
+
+# ---- Verify ----
+SO_FILE="${OUTPUT_DIR}/sdna_vs2008.so"
+echo ""
+echo "========================================"
+if [ -f "${SO_FILE}" ]; then
+    echo "BUILD SUCCESS"
+    echo "Output: ${SO_FILE}"
+    echo ""
+    echo "File size: $(du -h "${SO_FILE}" | cut -f1)"
+    echo ""
+
+    # Check OpenMP
+    echo -n "OpenMP support: "
+    if readelf -d "${SO_FILE}" 2>/dev/null | grep -q 'libgomp'; then
+        echo "YES — libgomp linked (multi-threaded)"
+    elif nm -D "${SO_FILE}" 2>/dev/null | grep -q 'GOMP_parallel'; then
+        echo "YES — GOMP symbols found (multi-threaded)"
+    else
+        echo "WARNING: No OpenMP detected — single-threaded build"
+    fi
+
+    # Check geos
+    echo -n "GEOS support:    "
+    if [ -f "${OUTPUT_DIR}/libgeos_c.so" ]; then
+        echo "YES — libgeos_c.so bundled"
+    else
+        echo "NO — geos not bundled (spatial operations may fail)"
+    fi
+
+    echo ""
+    echo "Quick test:"
+    echo "  export SDNADLL=${SO_FILE}"
+    echo "  cd sDNA/sdna_vs2008/tests"
+    echo "  python3 prepare_test_new.py"
+    echo ""
+    echo "To run benchmarks:"
+    echo "  pip install sdna-plus  # for Python bindings (or use arcscripts from output/)"
+
+    # ---- Offer permanent install ----
+    echo ""
+    echo "----------------------------------------"
+    REAL_USER="${SUDO_USER:-$USER}"
+    REAL_HOME="$(eval echo ~"${REAL_USER}")"
+    BASHRC="${REAL_HOME}/.bashrc"
+    EXPORT_LINE="export SDNADLL=\"${SO_FILE}\""
+    PATH_LINE="export PATH=\"\${PATH}:${SCRIPT_DIR}/output/Release/bin\""
+
+    echo "Make sDNA permanently available in new shells?"
+    echo "  This will add two lines to ${BASHRC}:"
+    echo "    ${EXPORT_LINE}"
+    echo "    ${PATH_LINE}"
+    echo ""
+    read -r -p "  Update ~/.bashrc? [y/N] " REPLY
+    echo ""
+
+    if [ "${REPLY,,}" = "y" ] || [ "${REPLY,,}" = "yes" ]; then
+        # Avoid duplicates
+        if [ -f "${BASHRC}" ]; then
+            if grep -qF "SDNADLL=" "${BASHRC}" 2>/dev/null; then
+                echo "sDNA entries already found in ${BASHRC} — skipping"
+            else
+                {
+                    echo ""
+                    echo "# sDNA+ (added by build_linux.sh on $(date -I))"
+                    echo "${EXPORT_LINE}"
+                    echo "${PATH_LINE}"
+                } >> "${BASHRC}"
+                echo "Added sDNA to ${BASHRC}"
+                echo "Run 'source ${BASHRC}' or open a new terminal to apply."
+            fi
+        else
+            {
+                echo "# sDNA+ (added by build_linux.sh on $(date -I))"
+                echo "${EXPORT_LINE}"
+                echo "${PATH_LINE}"
+            } > "${BASHRC}"
+            echo "Created ${BASHRC} with sDNA entries"
+        fi
+    else
+        echo "Skipped. To enable manually later:"
+        echo "  echo '${EXPORT_LINE}' >> ~/.bashrc"
+        echo "  echo '${PATH_LINE}' >> ~/.bashrc"
+    fi
+else
+    echo "BUILD FAILED — ${SO_FILE} not found"
+    exit 1
+fi

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -4,11 +4,16 @@ set -euo pipefail
 # build_linux.sh — Single-command Linux build for sDNA+
 # Produces output/Release/x64/sdna_vs2008.so with OpenMP support
 #
-# Usage:
-#   sudo bash build_linux.sh
+# Usage (does NOT need root):
+#   bash build_linux.sh
 #
-# Prerequisites are checked automatically. On a fresh Ubuntu/Debian system:
+# Install the prerequisites first (this is the only step that needs root).
+# On a fresh Ubuntu/Debian system:
 #   sudo apt install cmake make g++ libboost-dev python3
+#
+# Note: a recent CMake is required (see CMakeLists.txt for the exact minimum).
+# Some older distro CMake packages are too old; install a newer CMake from
+# Kitware's apt repo or pip (pip install cmake) if the configure step fails.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/build_linux"
@@ -32,7 +37,8 @@ done
 if [ -n "$MISSING" ]; then
     echo ""
     echo "ERROR: Required tools not found:$MISSING"
-    echo "Install with: sudo apt install cmake make g++ libboost-dev python3"
+    echo "Install them first (needs root), e.g. on Ubuntu/Debian:"
+    echo "  sudo apt install cmake make g++ libboost-dev python3"
     exit 1
 fi
 
@@ -167,7 +173,7 @@ if [ -f "${SO_FILE}" ]; then
 
     echo ""
     echo "Quick test:"
-    echo "  export SDNADLL=${SO_FILE}"
+    echo "  export SDNADLL=\"${SO_FILE}\""
     echo "  cd sDNA/sdna_vs2008/tests"
     echo "  python3 prepare_test_new.py"
     echo ""
@@ -177,9 +183,7 @@ if [ -f "${SO_FILE}" ]; then
     # ---- Offer permanent install ----
     echo ""
     echo "----------------------------------------"
-    REAL_USER="${SUDO_USER:-$USER}"
-    REAL_HOME="$(eval echo ~"${REAL_USER}")"
-    BASHRC="${REAL_HOME}/.bashrc"
+    BASHRC="${HOME}/.bashrc"
     EXPORT_LINE="export SDNADLL=\"${SO_FILE}\""
     PATH_LINE="export PATH=\"\${PATH}:${SCRIPT_DIR}/output/Release/bin\""
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -198,7 +198,7 @@ if [ -f "${SO_FILE}" ]; then
     if [ "${REPLY,,}" = "y" ] || [ "${REPLY,,}" = "yes" ]; then
         # Avoid duplicates
         if [ -f "${BASHRC}" ]; then
-            if grep -qF "SDNADLL=" "${BASHRC}" 2>/dev/null; then
+            if grep -qF "sdnadll=" "${BASHRC}" 2>/dev/null; then
                 echo "sDNA entries already found in ${BASHRC} — skipping"
             else
                 {

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -184,7 +184,7 @@ if [ -f "${SO_FILE}" ]; then
     echo ""
     echo "----------------------------------------"
     BASHRC="${HOME}/.bashrc"
-    EXPORT_LINE="export SDNADLL=\"${SO_FILE}\""
+    EXPORT_LINE="export sdnadll=\"${SO_FILE}\""
     PATH_LINE="export PATH=\"\${PATH}:${SCRIPT_DIR}/output/Release/bin\""
 
     echo "Make sDNA permanently available in new shells?"

--- a/sDNA/sdna_vs2008/CMakeLists.txt
+++ b/sDNA/sdna_vs2008/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_SYSTEM_VERSION 10.0 CACHE STRING "" FORCE)
 # https://learn.microsoft.com/en-gb/vcpkg/users/buildsystems/cmake-integration#cmake_toolchain_file
 
 
-if (IS_READABLE ENV{VCPKG_ROOT})
+if (IS_READABLE "$ENV{VCPKG_ROOT}")
     SET(VCPKG_ROOT 
     "$ENV{VCPKG_ROOT}"
     )
@@ -23,7 +23,7 @@ else()
 endif()
 
 set(CMAKE_TOOLCHAIN_FILE
-    "{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 )
  
 set(VCPKG_MANIFEST_DIR "${CMAKE_SOURCE_DIR}/../..")
@@ -210,6 +210,8 @@ set(boost_packages
 
 find_package(Boost REQUIRED)
 
+find_package(OpenMP)
+
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
@@ -365,7 +367,12 @@ add_library(${PROJECT_NAME} SHARED ${ALL_FILES})
 # If building with Ninja, by default libraries are prefixed with "lib"
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
+if(OpenMP_FOUND)
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES} OpenMP::OpenMP_CXX)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _OPENMP)
+else()
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
+endif()
 
 target_precompile_headers(${PROJECT_NAME} PRIVATE "stdafx.h")
 
@@ -966,6 +973,14 @@ elseif(WIN32) # E.g. zig c++ for Windows
         "_UNICODE"
     )
 else() # Not MSVC
+    find_package(OpenMP)
+    if(OpenMP_CXX_FOUND)
+        target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
+        target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
+        message(STATUS "OpenMP enabled for GCC/Linux build")
+    else()
+        message(WARNING "OpenMP not found — building single-threaded")
+    endif()
     target_compile_definitions(${PROJECT_NAME} PRIVATE
         "UNICODE;"
         "_UNICODE"

--- a/sDNA/sdna_vs2008/IteratorTypeErasure/any_iterator/detail/any_iterator_metafunctions.hpp
+++ b/sDNA/sdna_vs2008/IteratorTypeErasure/any_iterator/detail/any_iterator_metafunctions.hpp
@@ -36,6 +36,7 @@
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/not.hpp>
+#include <boost/mpl/if.hpp>
 
 namespace IteratorTypeErasure
 {

--- a/sDNA/sdna_vs2008/IteratorTypeErasure/any_iterator/detail/any_iterator_metafunctions.hpp
+++ b/sDNA/sdna_vs2008/IteratorTypeErasure/any_iterator/detail/any_iterator_metafunctions.hpp
@@ -36,6 +36,9 @@
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/not.hpp>
+// boost::mpl::if_ is used directly below (e.g. make_iterator_reference_const,
+// reference_types_erasure_compatible). Older Boost happened to pull this header
+// in transitively, but Boost >= ~1.75 no longer does, so include it explicitly.
 #include <boost/mpl/if.hpp>
 
 namespace IteratorTypeErasure

--- a/sDNA/sdna_vs2008/stdafx.h
+++ b/sDNA/sdna_vs2008/stdafx.h
@@ -84,7 +84,7 @@ using boost::numeric_cast;
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/multi/geometries/multi_point.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>


### PR DESCRIPTION
Single-command Linux build with OpenMP multi-threading.
- `sudo bash build_linux.sh` works out of the box on any modern Ubuntu/Debian
- CMake fixes: IS_READABLE, missing $ in vcpkg toolchain path
- OpenMP enabled for GCC/Linux builds via find_package(OpenMP)
- Boost 1.90 compatibility (added <boost/mpl/if.hpp>)
- Updated BUILD.md and README.md
- Optional ~/.bashrc setup for permanent SDNADLL PATH

Tested on Ubuntu 26.04 with GCC 15, Boost 1.90, CMake 4.2.