### PR TITLE
Delete manual injection of #def _OPENMP

### DIFF
--- a/sDNA/sdna_vs2008/CMakeLists.txt
+++ b/sDNA/sdna_vs2008/CMakeLists.txt
@@ -369,7 +369,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
 if(OpenMP_FOUND)
   target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES} OpenMP::OpenMP_CXX)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE _OPENMP)
 else()
   target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
 endif()


### PR DESCRIPTION
Delete: target_compile_definitions(${PROJECT_NAME} PRIVATE _OPENMP), it's done later natively by the compiler's themselves

I checked with ldd and the resulting sdna_vs2008.so still links to libgomp ... .so