### PR TITLE
C++23 and Boost 1.91.0.  Don't make Windows wheel silently fail.

### DIFF
--- a/.github/workflows/compile_so_with_gcc.yml
+++ b/.github/workflows/compile_so_with_gcc.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_and_upload_installer:
     name: "Compile on Ubuntu with CMake & GCC"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-26.04"
     # outputs:
     #   installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
@@ -63,7 +63,7 @@ jobs:
 
     name: "Download and run sDNA installer, and run diff tests on it. "
     
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-26.04"
 
 
     steps:

--- a/.github/workflows/smoke_test_gcc.yml
+++ b/.github/workflows/smoke_test_gcc.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_and_upload_output_dir:
     name: "Compile on Ubuntu with CMake & GCC"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-26.04"
     # outputs:
     #   installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
@@ -80,7 +80,7 @@ jobs:
 
     name: "Smoke test: ${{ matrix.smoke_test }}"
     
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-26.04"
 
 
     steps:

--- a/.github/workflows/test_Linux_OpenMP_build.yml
+++ b/.github/workflows/test_Linux_OpenMP_build.yml
@@ -46,8 +46,14 @@ jobs:
     - name: Install dependencies
       run: |
         apt update
-        apt install git cmake ninja-build g++ libboost-dev python3-venv python3-pip -y
+        apt install -y git cmake ninja-build g++ libboost-dev python3-venv python3-pip
     
+    - name: Update GCC to support C++23
+      if: ${{ matrix.container_image != 'ubuntu:26.04' && matrix.container_image != 'debian:trixie' }}
+      run: |
+        apt install -y g++-14
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 --slave /usr/bin/g++ g++ /usr/bin/g++-14
+
     - name: Checkout repository
       uses: actions/checkout@v5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DO_NOT_ERROR_ON_WARNING)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 23)
 if (MSVC)
     message("Configuring for Visual Studio")
 else()

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-# Based on CentOS 5
+# Based on Alma Linux
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 LABEL name="sDNA Linux Python Wheel Builder"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -84,12 +84,14 @@ class CustomHook(BuildHookInterface):
             config_command_str,
             shell=config.shell,
             env=env,
+            check = True,
         )
 
         subprocess.run(f"""
             cmake --build {build_dir} --config {config.build_config} --parallel {os.cpu_count()}
             """.lstrip().replace('\n',''),
-            shell=config.shell
+            shell=config.shell,
+            check=True,
         )
 
 

--- a/sDNA/sdna_vs2008/CMakeLists.txt
+++ b/sDNA/sdna_vs2008/CMakeLists.txt
@@ -34,7 +34,7 @@ set(PROJECT_NAME sdna_vs2008)
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Converting%20Existing%20Systems%20To%20CMake.html#converting-windows-based-workspaces
 project(${PROJECT_NAME} CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 23)
 
 # In CMake, the target Platform can be set for all Visual Studio Generators 
 # as far back as VS 2008 by setting

--- a/sDNA/sdna_vs2008/geos_sdna_wrapper.h
+++ b/sDNA/sdna_vs2008/geos_sdna_wrapper.h
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+#include <print>
+#include <string>
 #include "net.h"
 
 using namespace std;
@@ -141,7 +143,8 @@ public:
 
 		const char *dlsym_error = dlerror();
 		if (dlsym_error) {
-			std::cerr << "Error loading " << geos_dll_path_w << ", " << dlsym_error << std::endl;
+			std::cerr << "Error loading geos_dll_path_w, " << dlsym_error << std::endl;
+			// std::print("Error loading: {0}. dlsym_error: {1}\n", geos_dll_path_w, dlsym_error);
 			dlclose(hDLL);
 			hDLL = NULL;
 			return;
@@ -151,7 +154,18 @@ public:
 
 		if (hDLL == NULL)
 		{
-			cout << "geos_c.dll / geos_c.so not found at " << geos_dll_path_w << endl;
+			std::cerr << "Error loading geos_dll_path_w " << std::endl;
+
+			// #ifdef _WINDOWS
+			// std::wcout << "geos_c.dll / geos_c.so not found at: " <<  geos_dll_path_w;
+
+			// #else
+			// // On C++23 is stricter about sending wider strings to the narrow string cout.
+			// // geos_dll_path_w could be a wide string (containing non-ascii unicode code points).
+			// // cout << "geos_c.dll / geos_c.so not found at " << geos_dll_path_w << endl;
+			// std::print("geos_c.dll / geos_c.so not found at: {0}\n", geos_dll_path_w);
+			// #endif
+
 		}
 		else
 		{

--- a/sDNA/sdna_vs2008/linkdatasource.h
+++ b/sDNA/sdna_vs2008/linkdatasource.h
@@ -35,7 +35,7 @@ public:
 		delete[] p;
 	}
 };
-typedef variant<long,float,HeapString> SDNAVariant;
+typedef boost::variant<long,float,HeapString> SDNAVariant;
 
 class Net;
 struct FieldMetaData;

--- a/sDNA/sdna_vs2008/sdna_arrays.h
+++ b/sDNA/sdna_vs2008/sdna_arrays.h
@@ -59,7 +59,7 @@ template<class T,class INDEX> class IdIndexedArray
 {
 private:
 	IdIndexedArray& operator=(const IdIndexedArray<T,INDEX> &original);
-	IdIndexedArray<T,INDEX>(const IdIndexedArray<T,INDEX> &original);
+	IdIndexedArray(const IdIndexedArray<T,INDEX> &original);
 protected:
 	T * data;
 	size_t size;
@@ -154,7 +154,7 @@ private:
 	T dummy; //to return when not enabled
 
 	IdRadiusIndexed2dArray<T,INDEX>& operator=(const IdRadiusIndexed2dArray<T,INDEX> &other);
-	IdRadiusIndexed2dArray<T,INDEX>(const IdRadiusIndexed2dArray<T,INDEX> &other);
+	IdRadiusIndexed2dArray(const IdRadiusIndexed2dArray<T,INDEX> &other);
 public:
 	IdRadiusIndexed2dArray() : radii(0), will_be_used(false) {}
 	IdRadiusIndexed2dArray(size_t n,size_t r,T initval) : will_be_used(true)
@@ -321,7 +321,7 @@ public:
 		}
 		cout << endl;
 	}
-	NetAttachedData<T>(SDNAPolylineContainer *links) : links(links) {}
+	NetAttachedData(SDNAPolylineContainer *links) : links(links) {}
 private:
 	//quick test shows vector of names is faster than map for sizes <5
 	//for the most part though we access by index anyway

--- a/sDNA/sdna_vs2008/sdna_spatial_accumulators.h
+++ b/sDNA/sdna_vs2008/sdna_spatial_accumulators.h
@@ -30,7 +30,7 @@ template <typename T> class BidirectionalThreadSafeAccumulator
 	ThreadSafeAccumulator<T> fwd_data, bwd_data;
 	bool use_both_directions, is_initialized;
 public:
-	BidirectionalThreadSafeAccumulator<T>() : use_both_directions(false), is_initialized(false) {}
+	BidirectionalThreadSafeAccumulator() : use_both_directions(false), is_initialized(false) {}
 	void set_bidirectional() {assert(!is_initialized); use_both_directions=true;}
 	void enable()
 	{
@@ -183,9 +183,9 @@ public:
 	typename vector<T>::iterator end() {return v.end();}
 	
 	//copy constructor creates new mutex
-	ThreadSafeVector<T>(ThreadSafeVector<T> &other) : vector<T>(other) {}
+	ThreadSafeVector(ThreadSafeVector<T> &other) : vector<T>(other) {}
 	//default constructor needed because copy constructor suppresses it
-	ThreadSafeVector<T>() {} 
+	ThreadSafeVector() {} 
 	//assignment operator keeps same mutex
 	ThreadSafeVector<T>& operator=(ThreadSafeVector<T> &other) 
 	{

--- a/sDNA/sdna_vs2008/sdna_vs2008.vcxproj
+++ b/sDNA/sdna_vs2008/sdna_vs2008.vcxproj
@@ -438,6 +438,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -479,6 +480,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -518,6 +520,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -566,6 +569,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -611,6 +615,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -659,6 +664,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -704,6 +710,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -753,6 +760,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -799,6 +807,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -846,6 +855,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -891,6 +901,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -938,6 +949,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -982,6 +994,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -1023,6 +1036,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -1061,6 +1075,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -1103,6 +1118,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -1142,6 +1158,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -1190,6 +1207,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -1235,6 +1253,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -1276,6 +1295,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -1314,6 +1334,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <Outputs>$(OutDir)geos_c.dll;%(Outputs)</Outputs>
     </CustomBuildStep>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -1355,6 +1376,7 @@ python preppend_muparser_cpps_with_include_stdafx.h.py</Command>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
       <AdditionalOptions>/Zm140 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\muparser\drop\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/sDNA/sdna_vs2008/tests/pytest/test_gathering_windows_command_line_tests.py
+++ b/sDNA/sdna_vs2008/tests/pytest/test_gathering_windows_command_line_tests.py
@@ -1,4 +1,8 @@
-# -*- coding: utf-8 -*-
+# /// script
+# requires-python = "==2.7,>=3.5"
+# dependencies = []
+# ///
+# pytest is recommended, but optional
 
 import os
 import os.path
@@ -592,7 +596,19 @@ def almost_equal(a, b, abs_tol = 2e-15):
         
 
 
-
+INF_WARNING_LINES = {
+    "WARNING: Formula evaluation gave infinite result for link 0",
+    "(Further infinities may exist but may not be reported)",
+}
+NEGATIVE_OR_NAN_WARNING_LINES = (
+    "threw runtime exception Formula evaluation gave negative result for link 0",
+    "threw runtime exception Formula evaluation gave NaN (not a number) result for link 0",
+    "(This is usually the result of dividing zero by zero)",
+)
+RANDOM_FUNCTION_CALLS = (
+    "randnorm(0,1)",
+    "randuni(0,1)",
+)
 
 
 class DiffCommand(ReadsTextInputFile):
@@ -662,6 +678,7 @@ class DiffCommand(ReadsTextInputFile):
 
             prev_expected = ''
             i=0
+            extras_before = ""
             for i, (expected, actual) in enumerate(tuples_of_nontrivial_nonProgress_strings(
                                                         expected_lines,
                                                         output_so_far.split('\n'),
@@ -745,8 +762,26 @@ class DiffCommand(ReadsTextInputFile):
                     if actual.startswith('Progress:') and actual.endswith('-bit mode'):
                         actual = ''.join(actual.partition('sDNA is running in ')[1:])
 
-                assert almost_equal(actual, expected), '[101mError[0m on line num i: %s.  This line (and up to the %s previous ones):\nExpected: %s, \n\n Actual: %s' % (i+1, buffer_size - 1,'\n'.join(expected_buffer), '\n'.join(actual_buffer))
+                if expected in INF_WARNING_LINES and actual.endswith(expected):
+                    extras_before += actual.rsplit(expected, 1)[0] 
+                    m += 1
+                    continue
+                
+                if (expected.endswith(NEGATIVE_OR_NAN_WARNING_LINES) and
+                    actual.endswith(NEGATIVE_OR_NAN_WARNING_LINES)):
+                    m+=1
+                    extras_before=""
+                    continue
+                
+                if (expected.startswith(RANDOM_FUNCTION_CALLS) and 
+                    actual.startswith(RANDOM_FUNCTION_CALLS)):
+                    m+=1
+                    continue
+
+
+                assert almost_equal(extras_before + actual, expected), '[101mError[0m on line num i: %s.  This line (and up to the %s previous ones):\nExpected: %s, \n\n Actual: %s' % (i+1, buffer_size - 1,'\n'.join(expected_buffer), '\n'.join(actual_buffer))
                 # assert actual == expected, 'i: %s, Expected: "%s", Actual: "%s"' % (i, expected, actual)
+                extras_before=""
                 prev_expected = expected
                 m += 1
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,19 +2,22 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "baseline": "fc6345e114c2e2c4f9714037340ccb08326b3e8c"
+    "baseline": "d87340acc46bdeda386037b38aca30136e667e47"
   },
   "registries": [
     {
       "kind": "git",
       "repository": "https://github.com/microsoft/vcpkg",
-      "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
+      "baseline": "d87340acc46bdeda386037b38aca30136e667e47",
       "packages": [ "boost-modular-build-helper" ]
     },
     {
       "kind": "git",
       "repository": "https://github.com/Microsoft/vcpkg",
-      "baseline": "61f610845fb206298a69f708104a51d651872877",
+      "baseline": "d87340acc46bdeda386037b38aca30136e667e47",
+      "$baseline_date": "3rd July 2026",
+      "$boost_version": "1.91.0",
+      "$last_boost_update_PR_URL": "https://github.com/microsoft/vcpkg/pull/51397",
       "packages": [ "boost*", "boost-*" ]
     }
   ]


### PR DESCRIPTION
set(CMAKE_CXX_STANDARD 23)

TRy to fix some compiler errors

Get rid of intermediate local variables

std::variant => boost::variant

Bump Boost to 1.91.0. Set check=True in subprocess.run in Hatch build hook.

Update vcpkg-configuration.json

Use wcout instead of cout, to handle wide string file name.

Try std::print instead of cout and cerr

Include print and string

Don't #include <print>

Revert "Don't #include <print>"

This reverts commit 659af3d5f0438477efa5d66f1eb8e0a72a1b6f62.

Add errant ;

Update GCC on Ubuntu 24.04

Update test_Linux_OpenMP_build.yml

Don't need sudo

Don't isntall in interactive mode

Update test_Linux_OpenMP_build.yml

Run Linux jobs on Ubuntu 26.04, for gcc version supporting C++23

Set       <LanguageStandard>stdcpp23</LanguageStandard>

Update geos_sdna_wrapper.h

Update geos_sdna_wrapper.h

Don't use wcout or std::print

Set flush=True

Leave in "python -u" on sDNA command tests - don't use CLI

Update test_gathering_windows_command_line_tests.py

Revert "Update test_gathering_windows_command_line_tests.py"

This reverts commit 0f2d575c6e7ec352ea61cd9287f967d0a48d94ad.

Revert "Leave in "python -u" on sDNA command tests - don't use CLI"

This reverts commit 8ca020d1181049787108bcd19eb6782c554df64f.

Revert "Set flush=True"

This reverts commit 7b59022d7cbd64508a2c96df1d304c9d783a09d7.

Allow Infinity WARNINGs to appear later than in expected

Fix syntax

Fix variable  name

Add more warning lines.  Adjust correctout.txt

Revert changes to output.  Just use exception exceptions.

Allow the other types of warnings to absorb extracts out of order

Update test_gathering_windows_command_line_tests.py

Update correctout.txt

Update test_gathering_windows_command_line_tests.py